### PR TITLE
Add Mixpanel integration to enable UTM tracking on docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -149,5 +149,6 @@
       "light": "#111111",
       "dark": "#6C2A87"
     }
-  }
+  },
+  "integrations": { "mixpanel": { "projectToken": "f4732326d84c14f00a5dc597ae8dc8dc" } }
 }


### PR DESCRIPTION
Adds the existing Mayan Mixpanel project token to docs.json so docs.mayan.finance reports into the same Mixpanel project as swap.mayan.finance. Mintlify sends page views, search queries, feedback and nav clicks; the Mixpanel SDK picks up utm_source / utm_medium / utm_campaign automatically. No code changes, config only.